### PR TITLE
Fix Linux paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 *.bundle
 *.so
 *.o

--- a/lib/env_paths.rb
+++ b/lib/env_paths.rb
@@ -7,6 +7,7 @@ module EnvPaths
   HOMEDIR = Dir.home
 
   module Linux
+    # rubocop:disable Metrics/AbcSize
     def self.config(app_name)
       OSData.new(
         File.join(ENV.fetch('XDG_DATA_HOME', File.join(HOMEDIR, '.local', 'share')), app_name),

--- a/lib/env_paths.rb
+++ b/lib/env_paths.rb
@@ -9,11 +9,11 @@ module EnvPaths
   module Linux
     def self.config(app_name)
       OSData.new(
-        ENV.fetch('XDG_DATA_HOME', File.join(HOMEDIR, '.local', 'share', app_name)),
-        ENV.fetch('XDG_CONFIG_HOME', File.join(HOMEDIR, '.config', app_name)),
-        ENV.fetch('XDG_CACHE_HOME', File.join(HOMEDIR, '.cache', app_name)),
+        File.join(ENV.fetch('XDG_DATA_HOME', File.join(HOMEDIR, '.local', 'share')), app_name),
+        File.join(ENV.fetch('XDG_CONFIG_HOME', File.join(HOMEDIR, '.config')), app_name),
+        File.join(ENV.fetch('XDG_CACHE_HOME', File.join(HOMEDIR, '.cache')), app_name),
         # https://wiki.debian.org/XDGBaseDirectorySpecification#state
-        ENV.fetch('XDG_STATE_HOME', File.join(HOMEDIR, '.local', 'state', app_name)),
+        File.join(ENV.fetch('XDG_STATE_HOME', File.join(HOMEDIR, '.local', 'state')), app_name),
         File.join(Dir.tmpdir, Etc.getlogin, app_name)
       )
     end


### PR DESCRIPTION
### test

```ruby
ENV['XDG_CACHE_HOME'] = '~/my-cache-dir'
EnvPaths.get('my-app', suffix: false).cache
```

### before

    ~/my-cache-dir

### after

    ~/my-cache-dir/my-app